### PR TITLE
Add support for Tips mod on ProgressScreen

### DIFF
--- a/bclib.gradle
+++ b/bclib.gradle
@@ -37,6 +37,9 @@ dependencies {
 
     modCompileOnly "dev.emi:emi:${emi_version}"
     //modImplementation "dev.emi:emi:${emi_version}"
+
+    modImplementation "net.darkhax.tips:Tips-Fabric-${project.tips_version}"
+    modRuntimeOnly "net.darkhax.bookshelf:Bookshelf-Fabric-${project.bookshelf_version}"
 }
 
 processResources {

--- a/gradle.properties
+++ b/gradle.properties
@@ -14,3 +14,5 @@ archives_base_name=bclib
 # Dependencies
 modmenu_version=4.0.5
 emi_version=0.3.0+1.19
+tips_version=1.19.2:8.0.15
+bookshelf_version=1.19.2:16.1.5

--- a/src/main/java/org/betterx/bclib/client/BCLibClient.java
+++ b/src/main/java/org/betterx/bclib/client/BCLibClient.java
@@ -3,8 +3,11 @@ package org.betterx.bclib.client;
 import org.betterx.bclib.api.v2.ModIntegrationAPI;
 import org.betterx.bclib.api.v2.PostInitAPI;
 import org.betterx.bclib.api.v2.dataexchange.DataExchangeAPI;
+import org.betterx.bclib.client.gui.screens.ProgressScreen;
 import org.betterx.bclib.client.models.CustomModelBakery;
 import org.betterx.bclib.config.Configs;
+import org.betterx.bclib.integration.tips.Tips;
+import org.betterx.bclib.integration.tips.TipsIntegration;
 import org.betterx.bclib.registry.BaseBlockEntityRenders;
 import org.betterx.bclib.registry.PresetsRegistryClient;
 import org.betterx.worlds.together.WorldsTogether;
@@ -24,6 +27,9 @@ public class BCLibClient implements ClientModInitializer, ModelResourceProvider,
 
     @Override
     public void onInitializeClient() {
+        Tips.addTipsScreen(ProgressScreen.class);
+        ModIntegrationAPI.register(new TipsIntegration());
+
         WorldsTogetherClient.onInitializeClient();
         ModIntegrationAPI.registerAll();
         BaseBlockEntityRenders.register();

--- a/src/main/java/org/betterx/bclib/integration/tips/Tips.java
+++ b/src/main/java/org/betterx/bclib/integration/tips/Tips.java
@@ -1,0 +1,24 @@
+package org.betterx.bclib.integration.tips;
+
+import net.minecraft.client.gui.screens.Screen;
+
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * Integration, to provide a custom Screen class for Tips.
+ * <p>
+ * This integration allows you to use Tips without adding a dependency to your project. If the
+ * Mod is installed on the Client.
+ * <p>
+ * You can add a custom screen from your mod by calling {@link #addTipsScreen(Class)}.
+ * <p>
+ * Your custom screen should be a loading-like screen with space in the bottom left for tips.
+ */
+public class Tips {
+    static final Set<Class<? extends Screen>> screen = new HashSet<>();
+
+    public static void addTipsScreen(Class<? extends Screen> scr) {
+        screen.add(scr);
+    }
+}

--- a/src/main/java/org/betterx/bclib/integration/tips/TipsIntegration.java
+++ b/src/main/java/org/betterx/bclib/integration/tips/TipsIntegration.java
@@ -1,0 +1,28 @@
+package org.betterx.bclib.integration.tips;
+
+import net.darkhax.tipsmod.api.TipsAPI;
+import net.minecraft.client.gui.screens.Screen;
+import org.betterx.bclib.BCLib;
+import org.betterx.bclib.integration.ModIntegration;
+
+/**
+ * Internal class to use Tips classes, you should not need to use this class. If you want to register a
+ * Tips Screen for a Mod using BCLib, use {@link Tips#addTipsScreen(Class)}
+ */
+public class TipsIntegration extends ModIntegration {
+    public TipsIntegration() {
+        super("tipsmod");
+    }
+
+    @Override
+    public void init() {
+        try {
+            TipsAPI.class.getMethod("registerTipScreen", Class.class);
+            for (Class<? extends Screen> screen : Tips.screen) {
+                TipsAPI.registerTipScreen(screen);
+            }
+        } catch (NoSuchMethodException e) {
+            BCLib.LOGGER.warning("Tips Mod was detected, but doesn't have the right API. Please update Tips.");
+        }
+    }
+}


### PR DESCRIPTION
This PR adds optional support to the [Tips](https://www.curseforge.com/minecraft/mc-mods/tips) mod by adding `ProgressScreen` to the list of screens that tips can render on.

This was originally reported in https://github.com/Darkhax-Minecraft/Tips/issues/62, which led me to add to Tips' API the ability for mods to add modded screens to the renderable list https://github.com/Darkhax-Minecraft/Tips/pull/88.

Before this PR (Source: https://github.com/Darkhax-Minecraft/Tips/issues/62):
![image](https://user-images.githubusercontent.com/29845000/194690396-f5bed12a-510c-4006-adf7-ac2867f9aeec.png)

After this PR:
![image](https://user-images.githubusercontent.com/29845000/194690373-97b3d6c2-2069-4286-a552-ca0a60eee48c.png)
(Note: I think the weird rendering of the underline and lack of a percentage sign is due to the hacky way I forced the game to display this screen to test it. I didn't change anything in the `ProgressScreen` class, so it shouldn't be actually affected.)

I tried my best to make this PR fit in with the rest of the code base, but because I'm not familiar with BCLib I'm sure I made some mistakes when it comes to code style. Please let me know if you would like me to change anything :)