### PR TITLE
Only use fabric's mining level api to enforce ore mining levels

### DIFF
--- a/src/main/java/org/betterx/worlds/together/tag/v3/MineableTags.java
+++ b/src/main/java/org/betterx/worlds/together/tag/v3/MineableTags.java
@@ -16,7 +16,8 @@ public class MineableTags {
     public static final TagKey<Block> SWORD = FabricMineableTags.SWORD_MINEABLE;
     public static final TagKey<Block> HAMMER = TagManager.BLOCKS.makeCommonTag("mineable/hammer");
 
-    public static final TagKey<Block> NEEDS_NETHERITE_TOOL = TagManager.BLOCKS.makeCommonTag("needs_netherite_tool");
+    @Deprecated(forRemoval = true)
+    public static final TagKey<Block> NEEDS_NETHERITE_TOOL = TagManager.BLOCKS.makeTag("fabric", "needs_tool_level_4");
 
     static void prepareTags() {
     }


### PR DESCRIPTION
Fixes mining level incompatibilities for mods that don't derive tools from `TieredItem` (eg. Alloygery #86, Hephaestus, ...)

Also renames `#c:needs_netherite_tool` to `#fabric:needs_tool_level_4` to make netherite-level ores compatible with fabric's mining level api. All other mining levels tags were already compatible.

This fix only applies to 1.20-1.20.4, fabric's mining level api was removed in 1.20.5: https://github.com/FabricMC/fabric/pull/3664